### PR TITLE
feat: add new argument revoke_rules_on_delete for security-group resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,11 +19,12 @@ module "labels" {
 ## Below resource will deploy new security group in aws.
 ##-----------------------------------------------------------------------------
 resource "aws_security_group" "default" {
-  count       = var.enable && var.new_sg ? 1 : 0
-  name        = format("%s-sg", module.labels.id)
-  vpc_id      = var.vpc_id
-  description = var.sg_description
-  tags        = module.labels.tags
+  count                  = var.enable && var.new_sg ? 1 : 0
+  name                   = format("%s-sg", module.labels.id)
+  vpc_id                 = var.vpc_id
+  description            = var.sg_description
+  revoke_rules_on_delete = var.revoke_rules_on_delete
+  tags                   = module.labels.tags
   lifecycle {
     create_before_destroy = true
   }

--- a/variables.tf
+++ b/variables.tf
@@ -184,3 +184,9 @@ variable "prefix_list_address_family" {
   default     = "IPv4"
   description = "(Required, Forces new resource) The address family (IPv4 or IPv6) of prefix list."
 }
+
+variable "revoke_rules_on_delete" {
+  description = "Instruct Terraform to revoke all of the Security Groups attached ingress and egress rules before deleting the rule itself. Enable for EMR."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## what
* Added the `revoke_rules_on_delete = var.revoke_rules_on_delete` attribute to the security group configuration.

## why
* Ensures that associated security group rules are automatically revoked when the security group is deleted.

[## references
](https://github.com/terraform-aws-modules/terraform-aws-security-group/blob/v5.3.0/main.tf)