### PR TITLE
feat: add argument to pass extra tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ module "labels" {
   managedby   = var.managedby
   label_order = var.label_order
   repository  = var.repository
+  extra_tags  = var.tags
 }
 
 ##-----------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "repository" {
   description = "Terraform current module repo"
 }
 
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)."
+}
+
 variable "managedby" {
   type        = string
   default     = "hello@clouddrove.com"


### PR DESCRIPTION
### What
- Add argument `extra_tags` and variable `tags` to provide tags for security-group resource.
- To use this
  ```hcl
    module "security-group" {
        source + "../../"
        
        <-- OTHER CONFIGURAIONS -->
        tags = {
            "Environment" = "Test"
            "Project" = "CloudDrove"
        }

    }
  ```